### PR TITLE
Update golang version, strip go binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV LANGUAGE en_US.UTF-8
 
 ENV GOLANG_GOOS linux
 ENV GOLANG_GOARCH amd64
-ENV GOLANG_VERSION 1.7.5
+ENV GOLANG_VERSION 1.8.3
 
 ENV HOME /root
 ENV UTC true
@@ -35,6 +35,7 @@ RUN apt-get update && apt-get install -y \
 
 RUN curl -sSL https://golang.org/dl/go$GOLANG_VERSION.$GOLANG_GOOS-$GOLANG_GOARCH.tar.gz \
     | tar -v -C /usr/local -xz
+RUN strip /usr/local/go/bin/*
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /go


### PR DESCRIPTION
Stripping golang binaries results in ~10M data savings
```
14:32:51 holodeck ~ $ du -csh /tmp/go/go/bin/
28M	/tmp/go/go/bin/
28M	total
14:32:56 holodeck ~ $ strip /tmp/go/go/bin/*
14:33:02 holodeck ~ $ du -csh /tmp/go/go/bin/
19M	/tmp/go/go/bin/
19M	total
```