### PR TITLE
Tl/install apk tar package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV OS=linux ARCH=amd64 GO_VERSION=1.11.1 GOROOT=/usr/local/go GOPATH=/go
 ENV PATH="$GOPATH/bin:$GOROOT/bin:$PATH"
 
 RUN apk add --no-cache autoconf automake bash curl gcc g++ git make ncurses \
-	rpm xz upx python2 ruby ruby-dev cairo-dev nodejs nodejs-npm libc-dev \
+	tar rpm xz upx python2 ruby ruby-dev cairo-dev nodejs nodejs-npm libc-dev \
 	libc6-compat libffi-dev libpng-dev
 
 RUN curl -sSL https://golang.org/dl/go$GO_VERSION.$OS-$ARCH.tar.gz \


### PR DESCRIPTION
Fixes the following issue with building apk packages using fpm (https://github.com/jordansissel/fpm/issues/1375#issuecomment-317571946):
```
fpm -s dir -t apk -n csos-cli -v 1.0.0 \
	--package package/output/ \
	--iteration 929.gitb20c9b7 \
	--epoch 929 \
	--after-install scripts/rpm/post-install.sh \
	--before-remove scripts/rpm/pre-rm.sh \
	--after-remove scripts/rpm/post-rm.sh \
	--url "https://criticalstack.com" \
	--description "CSOS Client and Control Utility" \
	--maintainer "dev <dev@criticalstack.com>" \
	--vendor "Critical Stack" -a amd64 \
	--exclude */**.gitkeep \
	--force \
	package/root/=/
/usr/lib/ruby/gems/2.4.0/gems/fpm-1.10.2/lib/fpm/package/apk.rb:195:in `block (2 levels) in cut_tar_record': Invalid tar stream, eof before end-of-tar record (StandardError)
	from /usr/lib/ruby/gems/2.4.0/gems/fpm-1.10.2/lib/fpm/package/apk.rb:182:in `open'
	from /usr/lib/ruby/gems/2.4.0/gems/fpm-1.10.2/lib/fpm/package/apk.rb:182:in `block in cut_tar_record'
	from /usr/lib/ruby/gems/2.4.0/gems/fpm-1.10.2/lib/fpm/package/apk.rb:179:in `open'
	from /usr/lib/ruby/gems/2.4.0/gems/fpm-1.10.2/lib/fpm/package/apk.rb:179:in `cut_tar_record'
	from /usr/lib/ruby/gems/2.4.0/gems/fpm-1.10.2/lib/fpm/package/apk.rb:107:in `output'
	from /usr/lib/ruby/gems/2.4.0/gems/fpm-1.10.2/lib/fpm/command.rb:487:in `execute'
	from /usr/lib/ruby/gems/2.4.0/gems/clamp-1.0.1/lib/clamp/command.rb:68:in `run'
	from /usr/lib/ruby/gems/2.4.0/gems/fpm-1.10.2/lib/fpm/command.rb:574:in `run'
	from /usr/lib/ruby/gems/2.4.0/gems/clamp-1.0.1/lib/clamp/command.rb:133:in `run'
	from /usr/lib/ruby/gems/2.4.0/gems/fpm-1.10.2/bin/fpm:7:in `<top (required)>'
	from /usr/bin/fpm:23:in `load'
	from /usr/bin/fpm:23:in `<main>'
make: *** [Makefile:104: apk64] Error 1
```