### PR TITLE
Update golang to 1.11.2, replace package_cloud

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,17 +2,16 @@ FROM alpine:3.7
 
 MAINTAINER Dustin Willis Webber
 
-ENV OS=linux ARCH=amd64 GO_VERSION=1.11.1 GOROOT=/usr/local/go GOPATH=/go
+ENV OS=linux ARCH=amd64 GO_VERSION=1.11.2 GOROOT=/usr/local/go GOPATH=/go
 ENV PATH="$GOPATH/bin:$GOROOT/bin:$PATH"
 
-RUN apk add --no-cache autoconf automake bash curl gcc g++ git make ncurses \
-	tar rpm xz upx python2 ruby ruby-dev cairo-dev nodejs nodejs-npm libc-dev \
-	libc6-compat libffi-dev libpng-dev
-
-RUN curl -sSL https://golang.org/dl/go$GO_VERSION.$OS-$ARCH.tar.gz \
-	| tar -C /usr/local -xz && strip /usr/local/go/bin/* && \
-	mkdir -p /go /source && chmod -R 777 /go /source && \
-	go get -u -v golang.org/x/lint/golint && \
-	gem install fpm package_cloud thor-scmversion --no-ri --no-rdoc
+RUN apk add --no-cache autoconf automake bash curl gcc g++ git make rpm \
+	ncurses tar xz upx python2 ruby ruby-dev cairo-dev nodejs nodejs-npm \
+	libc-dev libc6-compat libffi-dev libpng-dev && \
+	mkdir -p /go && chmod 775 /go && \
+	curl -sSL https://golang.org/dl/go$GO_VERSION.$OS-$ARCH.tar.gz | \
+		tar -C /usr/local -xz && strip /usr/local/go/bin/* && \
+	go get -v github.com/tonylambiris/pkgcloud/cmd/... && \
+	gem install --no-ri --no-rdoc fpm thor-scmversion
 
 WORKDIR /source

--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ This image holds all the basic stuff when working with a golang application.
 
 ## Includes
 
-  * alpine linux
-  * go 1.9.1
+  * alpine linux 3.7
+  * go 1.11.2
   * love


### PR DESCRIPTION
I forked and updated a golang replacement for package_cloud included in this pull-request:
https://github.com/tonylambiris/pkgcloud

:metal: 